### PR TITLE
Exporting RDF conversion with wilbur, solving name conflicts in conllu.rdf

### DIFF
--- a/packages.lisp
+++ b/packages.lisp
@@ -85,7 +85,11 @@
 
 (defpackage #:conllu.rdf
   (:use #:cl #:wilbur #:alexandria #:cl-conllu)
-  (:export #:convert-filename))
+  (:shadowing-import-from #:cl-conllu
+			  #:query
+			  #:token)
+  (:export #:convert-filename
+	   #:convert-to-rdf))
 
 (defpackage #:conllu.converters.niceline
   (:use #:cl #:cl-conllu #:lispbuilder-lexer))


### PR DESCRIPTION
Loading cl-conllu from quicklisp was signalling name conflicts in conllu.rdf. This solves them with `shadowing-import-from`.

Exports also `convert-to-rdf`, from `rdf-wilbur.lisp`.