### PR TITLE
Debugging, refactoring and documenting evaluate.lisp

### DIFF
--- a/evaluate.lisp
+++ b/evaluate.lisp
@@ -38,33 +38,107 @@
 
 (defun token-diff (tk1 tk2 &key (fields *token-fields*) (test #'equal) (simple-dep nil))
   (loop for field in fields
-	for res = (if (and (equal field 'deprel) simple-dep)
-		      (funcall test
-			       (simple-deprel (slot-value tk1 field))
-			       (simple-deprel (slot-value tk2 field)))
-		      (funcall test
-			       (slot-value tk1 field)
-			       (slot-value tk2 field)))
-	unless res
-	collect (list field (slot-value tk1 field) (slot-value tk2 field))))
+     for res = (if (and (equal field 'deprel) simple-dep)
+		   (funcall test
+			    (simple-deprel (slot-value tk1 field))
+			    (simple-deprel (slot-value tk2 field)))
+		   (funcall test
+			    (slot-value tk1 field)
+			    (slot-value tk2 field)))
+     unless res
+     collect (list field (slot-value tk1 field) (slot-value tk2 field))))
 
 
 (defun sentence-diff (sent1 sent2 &key (fields *token-fields*)
-				    (test #'equal) (simple-dep nil) (punct t))
+                                    (test #'equal) (simple-dep nil) (ignore-punct nil))
+  "Returns a list of differences in SENT1 and SENT2.
+
+   They must have the same size.
+
+   If IGNORE-PUNCT, tokens which have 'PUNCT' as upostag
+   in sent2 are ignored."
+  
   (assert (equal (sentence-size sent1) (sentence-size sent2)))
-  (loop for tk1 in (remove-if (lambda (tk)
-				(and (not punct) (equal "PUNCT" (token-upostag tk))))
-			      (sentence-tokens sent1))
-	for tk2 in (remove-if (lambda (tk)
-				(and (not punct) (equal "PUNCT" (token-upostag tk))))
-			      (sentence-tokens sent2))
-	for diff = (token-diff tk1 tk2 :fields fields :test test :simple-dep simple-dep) 
-	when diff
-	collect (list (token-id tk1) diff)))
+  (let ((complete-diff
+	 (loop for tk1 in (sentence-tokens sent1)
+	    for tk2 in (sentence-tokens sent2)
+	    for diff = (token-diff tk1 tk2 :fields fields :test test :simple-dep simple-dep)
+	    when diff
+	    collect (list (token-id tk1) diff))))
+    (if ignore-punct
+	(remove-if
+	 #'(lambda (diff-entry)
+	     (let ((diff-entry-id (first diff-entry)))
+	       (equal "PUNCT"
+		      (token-upostag (find diff-entry-id
+					   (sentence-tokens sent2)
+					   :key #'token-id)))))
+	 complete-diff)
+	complete-diff)))
 
 
-(defun attachment-score-by-sentence (list-sent1 list-sent2 &key (fields *token-fields*)
-							     (punct t) (simple-dep nil))
+(defun sentence-average-score (list-sent1 list-sent2
+                               &key (fields *token-fields*)
+                                 (ignore-punct t) (simple-dep nil))
+  "Score by sentence (macro-average).
+
+   This is the mean of the percentage of words in each sentence
+   that are correct with respect to the fields in FIELDS.
+
+   We assume that LIST-SENT1 is the classified result
+   and LIST-SENT2 is the list of golden (correct) sentences.
+
+   If IGNORE-PUNCT, tokens which have 'PUNCT' as upostag
+   in the golden sentences are ignored."
+  
+  (let ((list-of-scores
+         (mapcar
+          #'(lambda (x y)
+              (- 1.0
+                 (/ (length (sentence-diff
+                             x y
+                             :fields fields
+                             :ignore-punct ignore-punct
+                             :simple-dep simple-dep))
+                    (sentence-size y))))
+          list-sent1 list-sent2)))
+    (/ (apply #'+ list-of-scores)
+       (float (length list-of-scores)))))
+
+
+(defun word-average-score (list-sent1 list-sent2
+                           &key (fields *token-fields*)
+                             (ignore-punct t) (simple-dep nil))
+  "Score by word (micro-average).
+
+   This is the total mean of words in all sentences that
+   are correct with respect to the fields in FIELDS.
+
+   We assume that LIST-SENT1 is the classified result
+   and LIST-SENT2 is the list of golden (correct) sentences.
+
+   If IGNORE-PUNCT, tokens which have 'PUNCT' as upostag
+   in the golden sentences are ignored."
+
+  (let ((total-words (apply #'+ (mapcar #'sentence-size list-sent1)))
+        (wrong-words (reduce #'+
+                             (mapcar
+                              #'(lambda (x y)
+                                  (sentence-diff
+                                   x y
+                                   :fields fields
+                                   :ignore-punct ignore-punct
+                                   :simple-dep simple-dep))
+                              list-sent1
+                              list-sent2)
+                             :key #'length
+                             :initial-value 0)))
+    (- 1.0 (/ wrong-words total-words))))
+
+
+(defun attachment-score-by-sentence (list-sent1 list-sent2
+                                     &key (labeled t)
+                                       (ignore-punct nil) (simple-dep nil))
   "Attachment score by sentence (macro-average).
 
    The attachment score is the percentage of words that have correct
@@ -73,104 +147,135 @@
    score (LAS) considers both the head and the arc label (dependency
    label / syntactic class).
 
-   References:
-     - Dependency Parsing. Kubler, Mcdonald and Nivre (pp.79-80)"
-  (let ((ns (mapcar #'(lambda (x y)
-			(- 1.0
-			   (/ (length (sentence-diff x y :fields fields
-						     :punct punct
-						     :simple-dep simple-dep))
-			      (sentence-size y))))
-		    list-sent1 list-sent2)))
-    (/ (apply #'+ ns) (float (length ns)))))
-
-
-(defun attachment-score-by-word (list-sent1 list-sent2 &key (fields *token-fields*)
-					    (punct t) (simple-dep nil))
-  "Attachment score by word (micro-average). See also the
-  `attachment-score-by-sentence`.
+   In order to choose between labeled or unlabeled,
+   set the key argument LABELED.
 
    References:
      - Dependency Parsing. Kubler, Mcdonald and Nivre (pp.79-80)"
-  (let ((total-words (apply #'+ (mapcar #'sentence-size list-sent1)))
-	(wrong-words (reduce #'+ (mapcar #'(lambda (x y)
-					     (sentence-diff x y :fields fields
-							    :punct punct
-							    :simple-dep simple-dep))
-					 list-sent1
-					 list-sent2)
-			     :key #'length
-			     :initial-value 0)))
-    (- 1.0 (/ wrong-words total-words))))
+  
+  (sentence-average-score list-sent1 list-sent2
+                          :fields (if labeled
+                                      '(head deprel)
+                                      '(head))
+                          :ignore-punct ignore-punct
+                          :simple-dep simple-dep))
 
 
-(defun recall (list-sent1 list-sent2 deprel &key (head-error nil) (label-error t) (simple-deprel nil))
-  "Restricted to words which are originally of syntactical class
-  (dependency type to head) `deprel`, returns the recall:
+(defun attachment-score-by-word (list-sent1 list-sent2
+				 &key (labeled t)
+				   (ignore-punct nil) (simple-dep nil))
+
+  "Attachment score by word (micro-average).
+
+   The attachment score is the percentage of words that have correct
+   arcs to their heads. The unlabeled attachment score (UAS) considers
+   only who is the head of the token, while the labeled attachment
+   score (LAS) considers both the head and the arc label (dependency
+   label / syntactic class).
+
+   In order to choose between labeled or unlabeled,
+   set the key argument LABELED.
+
+   References:
+     - Dependency Parsing. Kubler, Mcdonald and Nivre (pp.79-80)"
+
+  (word-average-score list-sent1 list-sent2
+		      :fields (if labeled
+				  '(head deprel)
+				  '(head))
+		      :ignore-punct ignore-punct
+		      :simple-dep simple-dep))
+
+
+(defun recall (list-sent1 list-sent2 deprel
+               &key (error-type '(deprel)) (simple-dep nil))
+  "Restricted to words which are originally of syntactic class
+  (dependency type to head) DEPREL, returns the recall:
    the number of true positives divided by the number of words
-   originally positive (that is, correctly of class `deprel`).
+   originally positive (that is, originally of class DEPREL).
 
-   head-error and label-error define what is considered an error (a
-   false negative)"
+   We assume that LIST-SENT1 is the classified result
+   and LIST-SENT2 is the list of golden (correct) sentences.
+
+   ERROR-TYPE defines what is considered an error (a false negative).
+   Some usual values are:
+    - '(deprel) :: for the deprel tagging task only
+    - '(head) :: for considering errors for each syntactic class
+    - '(deprel head) :: for considering correct only when both deprel
+                        and head are correct."
+
   (labels ((token-deprel-chosen (tk)
-	     (if simple-deprel
-		 (token-simple-deprel tk)
-		 (token-deprel tk))))
+             (if simple-dep
+                 (simple-deprel (token-deprel tk))
+                 (token-deprel tk))))
     (assert
-     (or head-error
-	 label-error)
+     (and (listp error-type)
+          (not (null error-type)))
      ()
-     "Error: At least one error must be used!")
+     "Error: ERROR-TYPE should be a list and at least one error must be used!")
     (let ((total-words
-	   (length
-	    (remove-if-not
-	     #'(lambda (x)
-		 (equal x deprel))
-	     (mappend #'sentence-tokens
-		      list-sent2)
-	     :key #'token-deprel-chosen)))
-	  (wrong-words
-	   (length
-	    (remove-if-not
-	     #'(lambda (x)
-		 (equal x deprel))
-	     (mappend
-	      #'identity
-	      (mapcar
-	       #'(lambda (sent1 sent2)
-		   (disagreeing-words
-		    sent1 sent2
-		    :head-error head-error
-		    :label-error label-error))
-	       list-sent1
-	       list-sent2))
-	     :key #'(lambda (disag-pair)
-		      (token-deprel-chosen
-		       (second disag-pair)))))))
+           (length
+            (remove-if-not
+             #'(lambda (x)
+                 (equal x deprel))
+             (mappend #'sentence-tokens
+                      list-sent2)
+             :key #'token-deprel-chosen)))
+          (wrong-words
+           (length
+            (mapcar
+             #'(lambda (sent1 sent2)
+                 (remove-if-not
+                  #'(lambda (x)
+                      (equal x deprel))
+                  (sentence-diff
+		   sent1 sent2
+		   :fields error-type
+		   :simple-dep simple-dep)
+                  :key
+                  ;; deprel in the original (SENT2) sentence
+                  #'(lambda (diff-entry)
+                      (let ((diff-entry-id (first diff-entry)))
+                        (token-deprel-chosen
+                         (find diff-entry-id
+                               (sentence-tokens sent2)
+                               :key #'token-id))))))
+             list-sent1
+             list-sent2))))
+      
       (if (eq total-words
 	      0)
-	  nil
+	  (warn "There are no tokens correctly of deprel ~a." deprel)
 	  (/ (float (- total-words wrong-words))
 	     total-words)))))
 
-(defun precision (list-sent1 list-sent2 deprel &key (head-error nil)
-						 (label-error t) (simple-deprel nil))
+(defun precision (list-sent1 list-sent2 deprel
+		  &key (error-type '(deprel)) (simple-dep nil))
   "Restricted to words which are classified as of syntactical class
-   (dependency type to head) `deprel`, returns the precision:
+   (dependency type to head) DEPREL, returns the precision:
    the number of true positives divided by the number of words
-   predicted positive (that is, predicted as of class `deprel`).
+   predicted positive (that is, predicted as of class DEPREL).
 
-   head-error and label-error define what is considered an error (a
-   false positive)"
+   We assume that LIST-SENT1 is the classified (predicted) result
+   and LIST-SENT2 is the list of golden (correct) sentences.
+
+   ERROR-TYPE defines what is considered an error (a false negative).
+   Some usual values are:
+    - '(deprel) :: for the deprel tagging task only
+    - '(head) :: for considering errors for each syntactic class
+    - '(deprel head) :: for considering correct only when both deprel
+                        and head are correct."
+  
   (labels ((token-deprel-chosen (tk)
-	     (if simple-deprel
-		 (token-simple-deprel tk)
+	     (if simple-dep
+		 (simple-deprel (token-deprel tk))
 		 (token-deprel tk))))
     (assert
-     (or head-error
-	 label-error)
+     (and (listp error-type)
+	  (not (null error-type)))
      ()
-     "Error: At least one error must be used!")
+     "Error: ERROR-TYPE should be a list and at least one error must be used!")
+    
     (let ((classified-words
 	   (length
 	    (remove-if-not
@@ -181,44 +286,47 @@
 	     :key #'token-deprel-chosen)))
 	  (wrong-words
 	   (length
-	    (remove-if-not
-	     #'(lambda (x)
-		 (equal x deprel))
-	     (mappend
-	      #'identity
-	      (mapcar
-	       #'(lambda (sent1 sent2)
-		   (disagreeing-words
-		    sent1 sent2
-		    :head-error head-error
-		    :label-error label-error))
-	       list-sent1
-	       list-sent2))
-	     :key #'(lambda (disag-pair)
-		      (token-deprel-chosen
-		       (first disag-pair)))))))
+	    (mapcar
+	     #'(lambda (sent1 sent2)
+		 (remove-if-not
+		  #'(lambda (x)
+		      (equal x deprel))
+		  (sentence-diff
+		   sent1 sent2
+		   :fields error-type
+		   :simple-dep simple-dep)
+		  :key
+		  ;; deprel in the predicted (SENT1) sentence
+		  #'(lambda (diff-entry)
+		      (let ((diff-entry-id (first diff-entry)))
+			(token-deprel-chosen
+			 (find diff-entry-id
+			       (sentence-tokens sent1)
+			       :key #'token-id))))))
+	     list-sent1
+	     list-sent2))))
       (if (eq classified-words
 	      0)
-	  nil
+	  (warn "There are no tokens predicted as of deprel ~a." deprel)
 	  (/ (float (- classified-words wrong-words))
 	     classified-words)))))
 
-(defun projectivity-accuracy (list-sent1 list-sent2)
+(defun non-projectivity-accuracy (list-sent1 list-sent2)
   (let ((N (length list-sent1))
 	(correct 0))
     (mapcar
      #'(lambda (x y)
-       (if (eq (non-projective? x)
-	       (non-projective? y))
-	   (incf correct)))
+	 (if (eq (non-projective? x)
+		 (non-projective? y))
+	     (incf correct)))
      list-sent1
      list-sent2)
     (if (eq N 0)
-	nil
+	(error "LIST-SENT1 is empty!")
 	(/ (float correct)
 	   N))))
 
-(defun projectivity-precision (list-sent1 list-sent2)
+(defun non-projectivity-precision (list-sent1 list-sent2)
   (let ((number-of-positives
 	 (length (remove-if-not
 		  #'non-projective?
@@ -234,12 +342,12 @@
      list-sent2)
     (if (eq 0
 	    number-of-positives)
-	nil
+	(warn "There are no non-projective sentences in LIST-SENT1")
 	(/ (float true-positives)
 	   number-of-positives))))
 
-(defun projectivity-recall (list-sent1 list-sent2)
-  (let ((number-of-projectives
+(defun non-projectivity-recall (list-sent1 list-sent2)
+  (let ((number-of-non-projectives
 	 (length (remove-if-not
 		  #'non-projective?
 		  list-sent2)))
@@ -247,22 +355,25 @@
     (mapcar
      #'(lambda (x y)
 	 (if (and
-	      (eq (non-projective? x) t)
-	      (eq (non-projective? y) t))
+	      (non-projective? x)
+	      (non-projective? y))
 	     (incf true-positives)))
      list-sent1
      list-sent2)
     (if (eq 0
-	    number-of-projectives)
-	nil
+	    number-of-non-projectives)
+	(warn "There are no non-projective sentences in LIST-SENT2")
 	(/ (float true-positives)
-	   number-of-projectives))))
+	   number-of-non-projectives))))
 
 
 (defun confusion-matrix (list-sent1 list-sent2 &key (normalize t))
   "Returns a hash table where keys are lists (deprel1 deprel2) and
    values are fraction of classifications as deprel1 of a word that
-   originally was deprel2."
+   originally was deprel2.
+
+   We assume that LIST-SENT1 is the classified result
+   and LIST-SENT2 is the list of golden (correct) sentences."
   (let* ((M (make-hash-table :test #'equal))
 	 (all-words-pair-list
 	  (mapcar
@@ -290,7 +401,8 @@
     
     (dolist (pair all-words-pair-list)
       (incf (gethash
-	     (mapcar #'token-simple-deprel
+	     (mapcar #'(lambda (tk)
+			 (simple-deprel (token-deprel tk)))
 		     pair)
 	     M)))
 


### PR DESCRIPTION
Some modifications are:

- `ignore-punct` (formerly just `punct`) key argument now correctly implemented in `sentence-diff`(what matters is only the original tag)
- `.*-average-score` are now general scoring functions accepting any combination of fields.
- `attachment-score-.*` are built on `.*-average-score` functions
- `recall`, `precision` and `confusion-matrix` are working again
- `projectivitity-.*`now correctly renamed to `non-projectivity-.*`