### PR TITLE
Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM lokedhs/sbcl-quicklisp:latest
+
+RUN apt-get install -y git
+WORKDIR /root/quicklisp/local-projects
+RUN git clone git@github.com:own-pt/cl-conllu.git
+
+RUN sbcl --quit --eval "(progn (ql:quickload :cl-conllu))"
+
+WORKDIR /home/
+ENTRYPOINT ["sbcl"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM lokedhs/sbcl-quicklisp:latest
 
 RUN apt-get install -y git
 WORKDIR /root/quicklisp/local-projects
-RUN git clone git@github.com:own-pt/cl-conllu.git
+RUN git clone https://github.com/own-pt/cl-conllu.git
 
 RUN sbcl --quit --eval "(progn (ql:quickload :cl-conllu))"
 


### PR DESCRIPTION
Although we already have quicklisp (so any docker image with quicklisp could already get `cl-conllu` from it), sometimes it would be useful to have a docker image with `cl-conllu` already installed and from the last version of the `master` branch.

I wrote this because I needed it for an experiment.

Would this be useful for the repository?

The dockerfile for the image used as base is https://github.com/lokedhs/sbcl-quicklisp/blob/master/Dockerfile