### PR TITLE
Confusion matrix

### DIFF
--- a/cl-conllu.asd
+++ b/cl-conllu.asd
@@ -27,6 +27,7 @@
 	       (:file "evaluate"           :depends-on ("data"))
 	       (:file "evaluate-template" :depends-on ("data"))
 	       (:file "query"              :depends-on ("data"))
+	       (:file "confusion-matrix" :depends-on ("data"))
 	       (:file "utils"              :depends-on ("data"))
 	       (:file "rdf"                :depends-on ("data"))
 	       (:file "rdf-wilbur"         :depends-on ("data"))

--- a/confusion-matrix.lisp
+++ b/confusion-matrix.lisp
@@ -7,6 +7,20 @@
 ;;;; meaning that the first analyses for the token labels it as L1,
 ;;;; while the second analyses labels it as L2.
 
+;;; Usage overview:
+;;
+;; For creating a new confusion matrix from two lists of sentence, use
+;; MAKE-CONFUSION-MATRIX.
+;; For the list of labels, use CONFUSION-MATRIX-LABELS.
+;; For accessing the cells, use CONFUSION-MATRIX-CELL-COUNT for the
+;; values and CONFUSION-MATRIX-CELL-TOKENS for the instances (in ids,
+;; not the objects).
+;; Notice that, by default, not necessarily the matrix is square, as
+;; not every pair LABEL1 LABEL2 is instantiated. For normalizing it,
+;; instantiating every possible LABEL1 LABEL2 pair with a cell with 0
+;; entries, use CONFUSION-MATRIX-NORMALIZE.
+
+
 ;;; class definition
 
 (in-package :cl-conllu)
@@ -272,7 +286,7 @@ matrix CM."
 
 ;;; content adjustment
 
-(defun normalize-confusion-matrix (cm)
+(defun confusion-matrix-normalize (cm)
   "Creates empty cells for each pair (LABEL1 LABEL2) of labels in
  (confusion-matrix-labels CM)."
   (let ((cm-labels (confusion-matrix-labels cm)))

--- a/confusion-matrix.lisp
+++ b/confusion-matrix.lisp
@@ -58,6 +58,9 @@
 ;; (defun get-labels cm
 ;;   ;; output: list of labels
 ;;   ...)
+;; (defun get-cells-labels cm
+;;   ;; output: list of pairs of labels
+;;   ...)
 ;; (defun get-cell-count (label1 label2 cm)
 ;;   ;; output: int
 ;;   ...)

--- a/confusion-matrix.lisp
+++ b/confusion-matrix.lisp
@@ -3,10 +3,6 @@
 ;;;;
 ;;;; For two sets of analyses of a set of sentences, a confusion matrix compares them with respect to a label for each token. Each token of a sentence is classified by a pair of labels (L1, L2), meaning that the first analyses for the token labels it as L1, while the second analyses labels it as L2.
 
-;;; TODOs
-;; todo: change token class definition to include pointers to sentence
-;; todo: change token initiation in order to include these pointers)
-
 ;;; class definition
 
 (in-package :cl-conllu)

--- a/confusion-matrix.lisp
+++ b/confusion-matrix.lisp
@@ -112,9 +112,19 @@
 	  '()
 	  "Different tokens are being compared! Tokens ~a and ~a do not have the same FORM. ~%Perhaps different sentences are being compared."
 	  token1 token2)
-  ...)
+
+  (insert-entry-confusion-matrix
+   (funcall (cm-key-fn cm)
+	    token1)
+   (funcall (cm-key-fn cm)
+	    token2)
+   token1
+   cm))
 
 (defun insert-entry-confusion-matrix (label1 label2 token cm)
+  ;; check if label1 x label2 already exists in cm
+  ;; label1 in rows
+  ;; label2 in columns
   ...)
   
 ;;; column creation

--- a/confusion-matrix.lisp
+++ b/confusion-matrix.lisp
@@ -36,17 +36,6 @@
   (setf (cm-columns obj)
 	(make-hash-table :test test-fn)))
 
-;;; column creation
-
-;;; initialization
-
-(defun make-confusion-matrix (sents-1 sents-2
-			      &key key-fn test-fn)
-  ...)
-
-(defun update-confusion-matrix (sents-1 sents-2 cm)
-  ...)
-
 ;;; Utility functions
 
 (defun get-labels cn
@@ -65,3 +54,68 @@
 (defun get-exact-match-sentences (cn)
   ;; output: list of strings (sent-id)
   ...)
+
+;;; initialization
+
+(defun make-confusion-matrix (list-sent1 list-sent2
+			      &key key-fn test-fn)
+  (assert (equal
+	   (length list-sent1)
+	   (length list-sent2))
+	  '()
+	  "LIST-SENT1 and LIST-SENT2 should have the same number of sentences!")
+  (let ((cm ...))
+    (mapc
+     #'(lambda (sent1 sent2)
+	 ...)
+     list-sent1
+     list-sent2)
+    cm))
+
+(defun update-confusion-matrix (list-sent1 list-sent2 cm)
+  ...)
+
+;;; low-level updating
+
+(defun update-confusion-matrix-sentences (sent1 sent2 cm)
+  (assert (equal
+	   (sentence-size sent1)
+	   (sentence-size sent2))
+	  '()
+	  "SENTENCES~%~a~%and~%~a~% do not have the same number of tokens!"
+	  sent1
+	  sent2)
+  (assert (equal
+	   (sentence-id sent1)
+	   (sentence-id sent2))
+	  '()
+	  "SENTENCES~%~a~%and~%~a~% do not have the same ID!"
+	  sent1
+	  sent2)
+  (mapc
+   #'(lambda (tk1 tk2)
+       (update-confusion-matrix-tokens
+	tk1 tk2 cm))
+   (sentence-tokens sent1)
+   (sentence-tokens sent2)))
+
+(defun update-confusion-matrix-tokens (token1 token2 cm)
+  (assert (equal
+	   (token-id token1)
+	   (token-id token2))
+	  '()
+	  "Different tokens are being compared! Tokens ~a and ~a do not have the same ID. ~%Perhaps different sentences are being compared."
+	  token1 token2)
+  (assert (equal
+	   (token-form token1)
+	   (token-form token2))
+	  '()
+	  "Different tokens are being compared! Tokens ~a and ~a do not have the same FORM. ~%Perhaps different sentences are being compared."
+	  token1 token2)
+  ...)
+
+(defun insert-entry-confusion-matrix (label1 label2 token cm)
+  ...)
+  
+;;; column creation
+

--- a/confusion-matrix.lisp
+++ b/confusion-matrix.lisp
@@ -1,0 +1,67 @@
+;;;; Confusion matrices
+;;;; class definition, initiatlization, formatting, auxiliary functions, etc
+;;;;
+;;;; For two sets of analyses of a set of sentences, a confusion matrix compares them with respect to a label for each token. Each token of a sentence is classified by a pair of labels (L1, L2), meaning that the first analyses for the token labels it as L1, while the second analyses labels it as L2.
+
+;;; TODOs
+;; todo: change token class definition to include pointers to sentence
+;; todo: change token initiation in order to include these pointers)
+
+;;; class definition
+
+(in-package :cl-conllu)
+
+(defclass confusion-matrix ()
+  ((corpus-id :initarg :corpus-id
+	      :accessor :cm-corpus-id
+	      :documentation "Identifier of the corpus or experiment.")
+   (key-fn :initarg :key-fn
+	   :initform #'token-upostag
+	   :accessor :cm-key-fn
+	   :documentation "Function used to label each token.")
+   (test-fn :initarg :test-fn
+	    :initform #'equal
+	    :accessor :cm-test-fn
+	    :documentation "Function which compares two labels. Typically a form of equality.")
+   (columns :accessor :cm-columns
+	    :documentation "Parameter which contains the contents of the confusion matrix."
+	    ;; Hash table which maps to rows, which maps to a pair
+	    ;; (count . list), where the list is a list of
+	    ;; (sentence-id . token-id)
+	    )))
+
+(defmethod print-object ... ...)
+(defmethod initialize-instance :after
+    ((obj confusion-matrix) &key test-fn &allow-other-keys)
+  (setf (cm-columns obj)
+	(make-hash-table :test test-fn)))
+
+;;; column creation
+
+;;; initialization
+
+(defun make-confusion-matrix (sents-1 sents-2
+			      &key key-fn test-fn)
+  ...)
+
+(defun update-confusion-matrix (sents-1 sents-2 cm)
+  ...)
+
+;;; Utility functions
+
+(defun get-labels cn
+  ;; output: list of labels
+  ...)
+(defun get-cell-count (label1 label2 cn)
+  ;; output: int
+  ...)
+(defun get-cell-tokens (label1 label2 cn)
+  ;; output: list of (sent-id . token-id)
+  ...)
+
+(defun get-sentences-ids (cn)
+  ;; output: list of strings
+  ...)
+(defun get-exact-match-sentences (cn)
+  ;; output: list of strings (sent-id)
+  ...)

--- a/confusion-matrix.lisp
+++ b/confusion-matrix.lisp
@@ -1,7 +1,11 @@
 ;;;; Confusion matrices
 ;;;; class definition, initiatlization, formatting, auxiliary functions, etc
 ;;;;
-;;;; For two sets of analyses of a set of sentences, a confusion matrix compares them with respect to a label for each token. Each token of a sentence is classified by a pair of labels (L1, L2), meaning that the first analyses for the token labels it as L1, while the second analyses labels it as L2.
+;;;; For two sets of analyses of a set of sentences, a confusion
+;;;; matrix compares them with respect to a label for each token. Each
+;;;; token of a sentence is classified by a pair of labels (L1, L2),
+;;;; meaning that the first analyses for the token labels it as L1,
+;;;; while the second analyses labels it as L2.
 
 ;;; class definition
 
@@ -18,16 +22,19 @@
    (test-fn :initarg :test-fn
 	    :initform #'equal
 	    :accessor cm-test-fn
-	    :documentation "Function which compares two labels. Typically a form of equality.")
+	    :documentation "Function which compares two labels.
+	    Typically a form of equality.")
    (sort-fn :initarg :sort-fn
 	    :initform #'(lambda (x y)
 			  (string<=
 			   (format nil "~a" x)
 			   (format nil "~a" y)))
 	    :accessor cm-sort-fn
-	    :documentation "Function which sorts labels.")
+	    :documentation "Function which sorts labels. By default,
+	    converts labels to string and uses lexicographical order")
    (rows :accessor cm-rows
-	 :documentation "Parameter which contains the contents of the confusion matrix."
+	 :documentation "Parameter which contains the contents of the
+	 confusion matrix."
 	 ;; Hash table which maps to rows, which are themselves
 	 ;; hash tables that maps to an array #(COUNT LIST), where
 	 ;; LIST is a list of (sentence-id . token-id)
@@ -102,6 +109,8 @@ by LABEL1 LABEL2 in the confusion matrix CM."
 	       label2))))
 
 (defun confusion-matrix-cell-tokens (label1 label2 cm)
+  "Returns the list of (SENT-ID . TOKEN-ID) of tokens in the cell
+LABEL1 LABEL2."
   ;; output: list of (sent-id . token-id)
   (let ((entry-array
 	 (gethash label2
@@ -114,6 +123,7 @@ by LABEL1 LABEL2 in the confusion matrix CM."
 	       label1
 	       label2))))
 
+;; TODO
 ;; (defun confusion-matrix-sentences-ids (cm)
 ;;   ;; output: list of strings
 ;;   ...)
@@ -125,6 +135,8 @@ by LABEL1 LABEL2 in the confusion matrix CM."
 
 (defun make-confusion-matrix (list-sent1 list-sent2
 			      &key (key-fn #'token-upostag) (test-fn #'equal) corpus-id)
+  "Creates a new confusion matrix from the lists of sentences
+LIST-SENT1 and LIST-SENT2."
   (assert (equal
 	   (length list-sent1)
 	   (length list-sent2))
@@ -137,6 +149,8 @@ by LABEL1 LABEL2 in the confusion matrix CM."
     (update-confusion-matrix list-sent1 list-sent2 cm)))
 
 (defun update-confusion-matrix (list-sent1 list-sent2 cm)
+  "Updates an existing confusion matrix by a list of sentences
+LIST-SENT1 and LIST-SENT2."
   (assert (equal
 	   (length list-sent1)
 	   (length list-sent2))
@@ -152,6 +166,9 @@ by LABEL1 LABEL2 in the confusion matrix CM."
 ;;; low-level updating
 
 (defun update-confusion-matrix-sentences (sent1 sent2 cm)
+  "Updates an existing confusion matrix by a pair of matching
+sentences SENT1 and SENT2. That is, SENT1 and SENT2 should be
+alternative analyses of the same natural language sentence."
   (assert (equal
 	   (sentence-size sent1)
 	   (sentence-size sent2))
@@ -248,7 +265,7 @@ matrix CM."
 	     2
 	     :initial-contents '(0 ()) )))))
 
-;;; content (hash) adjustment
+;;; content adjustment
 
 (defun normalize-confusion-matrix (cm)
   "Creates empty cells for each pair (LABEL1 LABEL2) of labels in

--- a/data.lisp
+++ b/data.lisp
@@ -31,7 +31,8 @@
 	    :accessor token-deps)
    (misc    :initarg :misc
 	    :initform "_"
-	    :accessor token-misc)))
+	    :accessor token-misc)
+   (sentence :accessor token-sentence)))
 
 
 (defclass mtoken ()
@@ -73,6 +74,15 @@
 	    (slot-value obj 'id) (slot-value obj 'deprel) (slot-value obj 'head))))
 
 
+(defmethod initialize-instance :after ((obj sentence)
+				       &key tokens &allow-other-keys)
+  "Sets the TOKEN-SENTENCE slot for each token attributed to the
+initialize sentence OBJ."
+  (mapc
+   #'(lambda (tk)
+       (setf (token-sentence tk)
+	     obj))
+   tokens))
 (defun sentence-matrix (sentence)
   (let ((arr (make-array (list (length (sentence-tokens sentence)) 10)))
 	(tb '(0 id 1 form 2 lemma 3 upostag 4 xpostag 5 feats 6 head 7 deprel 8 deps 9 misc)))

--- a/packages.lisp
+++ b/packages.lisp
@@ -80,7 +80,15 @@
 	   #:convert-rdf
 	   #:convert-rdf-file
 
-	   #:convert-to-rdf))
+	   #:convert-to-rdf
+
+	   #:confusion-matrix
+	   #:confusion-matrix-labels
+	   #:confusion-matrix-cells-labels
+	   #:confusion-matrix-cell-count
+	   #:confusion-matrix-cell-tokens
+	   #:make-confusion-matrix
+	   #:update-confusion-matrix))
   
 
 (defpackage #:conllu.prolog

--- a/packages.lisp
+++ b/packages.lisp
@@ -49,6 +49,7 @@
 	   #:token-deprel
 	   #:token-deps
 	   #:token-misc
+	   #:token-sentence
 
 	   #:form
 	   #:lemma

--- a/packages.lisp
+++ b/packages.lisp
@@ -89,7 +89,8 @@
 	   #:confusion-matrix-cell-tokens
 	   #:confusion-matrix-corpus-id
 	   #:make-confusion-matrix
-	   #:confusion-matrix-update))
+	   #:confusion-matrix-update
+	   #:confusion-matrix-normalize))
   
 
 (defpackage #:conllu.prolog

--- a/packages.lisp
+++ b/packages.lisp
@@ -87,8 +87,9 @@
 	   #:confusion-matrix-cells-labels
 	   #:confusion-matrix-cell-count
 	   #:confusion-matrix-cell-tokens
+	   #:confusion-matrix-corpus-id
 	   #:make-confusion-matrix
-	   #:update-confusion-matrix))
+	   #:confusion-matrix-update))
   
 
 (defpackage #:conllu.prolog


### PR DESCRIPTION
- Defines the `confusion-matrix` class and necessary functions for creating, printing, updating and accessing it.

- Alters the `token` class in order to have a slot for its original sentence. This slot is automatically setted by instantiation a new `sentence` (see `defmethod initialize-instance :after ((obj sentence)...)`)

- Modifies package and system definition in order to include `confusion-matrix`. 