### PR TITLE
improve lazy reader

### DIFF
--- a/packages.lisp
+++ b/packages.lisp
@@ -25,6 +25,7 @@
 	   #:read-file
 	   #:read-directory
 	   #:read-conllu
+           #:lazy-stream-reader
 	   #:query
 	   #:query-as-json
 	   #:write-conllu
@@ -33,8 +34,8 @@
 	   #:diff
 
 	   #:sentence-binary-tree
-	   ; #:insert-token
-	   ; #:remove-token
+         ; #:insert-token
+         ; #:remove-token
 	   #:adjust-sentence
 	   #:non-projective?
 

--- a/read-write.lisp
+++ b/read-write.lisp
@@ -81,31 +81,29 @@
     (read-stream in :fn-meta fn-meta)))
 
 
-(defun read-stream (stream &key (fn-meta #'collect-meta))
+(defun read-stream (stream &key (fn-meta #'collect-meta) (stop? #'null))
   (macrolet ((flush-line ()
 	       `(setq line (read-line stream nil nil)
-		      lineno (+ lineno 1))))
+		      lineno (1+ lineno))))
     (prog (line (lineno 0) begining lines sentences)
      label-1
      (flush-line)
-     (alexandria:switch (line :test #'equal)
-       (nil (go label-3))
-       ("" (go label-1))
-       (t (setq begining lineno)
-	  (push line lines)
-	  (go label-2)))
+     (cond  ((or (null line) (funcall stop? line))  (go label-3)) 
+	    ((equal line "") (go label-1))
+	    (t (setq begining lineno)
+	       (push line lines)
+	       (go label-2)))
      
      label-2
      (flush-line)
-     (alexandria:switch (line :test #'equal)
-       (nil (go label-3))
-       ("" (push (make-sentence begining (reverse lines) fn-meta)
-		 sentences)
-	   (setq lines nil)
-	   (go label-1))
-       (t (push line lines)
-	  (go label-2)))
-
+     (cond ((or (null line) (funcall stop? line)) (go label-3))
+	   ((equal line "") (push (make-sentence begining (reverse lines) fn-meta)
+				  sentences)
+	    (setq lines nil)
+	    (go label-1))
+	   (t (push line lines)
+	      (go label-2)))
+     
      label-3
      (if lines
 	 (push (make-sentence begining (reverse lines) fn-meta)

--- a/utils.lisp
+++ b/utils.lisp
@@ -143,3 +143,6 @@
 	      ;; No violation
 	      (push pair interval)))))))
 
+
+(defun blank-line? (line)
+  (cl-ppcre:scan "^[\t ]*$" line))


### PR DESCRIPTION
- change lazy-conllu-reader so that it only returns nil when it reaches EOF
  - previously it would return nil if there where more than one blank
    line after a sentence (which is against the standard, but is also
    pretty common)
- fix typo