### PR TITLE
(data) add function to access MISC key-value pairs

### DIFF
--- a/data.lisp
+++ b/data.lisp
@@ -427,3 +427,11 @@ initialize sentence OBJ."
 		      (nth x (sentence-mtokens sent-1))
 		      (nth x (sentence-mtokens sent-2)))
 	       (return nil))))))
+
+(defun token-misc-value  (token misc-key)
+  "Assume token's MISC is a list of key-value pairs, return value
+  corresponding to key MISC-KEY."
+  (let* ((misc-str (token-misc token))
+         (misc-elems (split-sequence:split-sequence #\| misc-str))
+         (misc-pairs (mapcar (alexandria:curry #'split-sequence:split-sequence #\=) misc-elems)))
+    (second (assoc misc-key misc-pairs :test #'string=))))

--- a/data.lisp
+++ b/data.lisp
@@ -434,4 +434,9 @@ initialize sentence OBJ."
   (let* ((misc-str (token-misc token))
          (misc-elems (split-sequence:split-sequence #\| misc-str))
          (misc-pairs (mapcar (alexandria:curry #'split-sequence:split-sequence #\=) misc-elems)))
+    (mapc (lambda (pair) (when (not (cdr pair))
+                           (format *error-output*
+                                   "token-misc-value: MISC field not a key-value pair: ~a"
+                                   (car pair))))
+          misc-pairs)
     (second (assoc misc-key misc-pairs :test #'string=))))


### PR DESCRIPTION
the conllu format demands that the MISC field be a list; it is often a
list of key-value pairs. the library should provide a function to
access these to avoid code repetition in applications that use it.